### PR TITLE
escapeTransformDescription is not a service/helper. replaced with agT…

### DIFF
--- a/view/zf-apigility-documentation/operation.phtml
+++ b/view/zf-apigility-documentation/operation.phtml
@@ -38,7 +38,7 @@ $collapseId        = $this->escapeHtmlAttr(sprintf('ops-collapse-%s-%s%s', $serv
                             <tr>
                                 <td><?php echo $this->escapeHtml($field->getName()) ?></td>
                                 <td><?php echo $this->escapeHtml($field->getFieldType() ?: '') ?></td>
-                                <td><?php echo $this->escapeTransformDescription($field->getDescription()) ?></td>
+                                <td><?php echo $this->agTransformDescription($field->getDescription()) ?></td>
                                 <td class="center-block"><span class="badge"><?php echo ($field->isRequired()) ? 'YES' : 'NO' ?></span></td>
                             </tr>
                         <?php


### PR DESCRIPTION
…ransformDescription, which i think was the intent of the previous developer.